### PR TITLE
Rtc

### DIFF
--- a/src/x86_64/kernel/drivers/include/rtc.h
+++ b/src/x86_64/kernel/drivers/include/rtc.h
@@ -1,0 +1,34 @@
+
+#ifndef RTC_H
+#define RTC_H
+#include <stdint.h>
+#include <IO.h>
+#include <stdio.h>
+
+#define CMOS_ADDRESS 0x70
+#define CMOS_DATA 0x71
+
+uint8_t second;
+uint8_t minute;
+uint8_t hour;
+uint8_t day;
+uint8_t month;
+uint32_t year;
+
+typedef struct datetime {
+	uint8_t second;
+	uint8_t minute;
+	uint8_t hour;
+	uint8_t day;
+	uint8_t month;
+	uint32_t year;
+} datetime_t;
+
+uint8_t read_cmos(uint8_t address);
+uint8_t get_update_in_progress_flag();
+
+void read_rtc();
+
+datetime_t get_datetime();
+
+#endif

--- a/src/x86_64/kernel/drivers/include/timer.h
+++ b/src/x86_64/kernel/drivers/include/timer.h
@@ -9,4 +9,8 @@
 
 void init_timer(uint32_t freq);
 
+uint64_t ms_since_bootup();
+
+void sleep(uint64_t ms);
+
 #endif

--- a/src/x86_64/kernel/drivers/rtc.c
+++ b/src/x86_64/kernel/drivers/rtc.c
@@ -1,0 +1,110 @@
+
+#include <rtc.h>
+
+#define CURRENT_YEAR 2018 // Change this each year!
+
+uint8_t century_register = 0x00; // Set by ACPI table parsing code if possible
+
+datetime_t get_datetime() {
+	read_rtc();
+	datetime_t dt;
+	dt.second = second;
+	dt.minute = minute;
+	dt.hour = hour;
+	dt.day = day;
+	dt.month = month;
+	dt.year = year;
+	return dt;
+}
+
+uint8_t read_cmos(uint8_t address) {
+	uint8_t data;
+	outportb(CMOS_ADDRESS, address);
+	data = inportb(CMOS_DATA);
+	return data;
+}
+
+uint8_t get_update_in_progress_flag() { return read_cmos(0x0A) & 0x80; }
+
+void read_rtc() {
+	uint8_t century;
+	uint8_t last_second;
+	uint8_t last_minute;
+	uint8_t last_hour;
+	uint8_t last_day;
+	uint8_t last_month;
+	uint8_t last_year;
+	uint8_t last_century;
+	uint8_t registerB;
+
+	// Note: This uses the "read registers until you get the same values twice
+	// in a row" technique
+	//       to avoid getting dodgy/inconsistent values due to RTC updates
+
+	while(get_update_in_progress_flag())
+		; // Make sure an update isn't in progress
+	second = read_cmos(0x00);
+	minute = read_cmos(0x02);
+	hour = read_cmos(0x04);
+	day = read_cmos(0x07);
+	month = read_cmos(0x08);
+	year = read_cmos(0x09);
+	if(century_register != 0) {
+		century = read_cmos(century_register);
+	}
+
+	do {
+		last_second = second;
+		last_minute = minute;
+		last_hour = hour;
+		last_day = day;
+		last_month = month;
+		last_year = year;
+		last_century = century;
+
+		while(get_update_in_progress_flag())
+			; // Make sure an update isn't in progress
+		second = read_cmos(0x00);
+		minute = read_cmos(0x02);
+		hour = read_cmos(0x04);
+		day = read_cmos(0x07);
+		month = read_cmos(0x08);
+		year = read_cmos(0x09);
+		if(century_register != 0) {
+			century = read_cmos(century_register);
+		}
+	} while((last_second != second) || (last_minute != minute) ||
+			(last_hour != hour) || (last_day != day) || (last_month != month) ||
+			(last_year != year) || (last_century != century));
+
+	registerB = read_cmos(0x0B);
+
+	// Convert BCD to binary values if necessary
+
+	if(!(registerB & 0x04)) {
+		second = (second & 0x0F) + ((second / 16) * 10);
+		minute = (minute & 0x0F) + ((minute / 16) * 10);
+		hour = ((hour & 0x0F) + (((hour & 0x70) / 16) * 10)) | (hour & 0x80);
+		day = (day & 0x0F) + ((day / 16) * 10);
+		month = (month & 0x0F) + ((month / 16) * 10);
+		year = (year & 0x0F) + ((year / 16) * 10);
+		if(century_register != 0) {
+			century = (century & 0x0F) + ((century / 16) * 10);
+		}
+	}
+
+	// Convert 12 hour clock to 24 hour clock if necessary
+
+	if(!(registerB & 0x02) && (hour & 0x80)) {
+		hour = ((hour & 0x7F) + 12) % 24;
+	}
+
+	// Calculate the full (4-digit) year
+
+	if(century_register != 0) {
+		year += century * 100;
+	} else {
+		year += (CURRENT_YEAR / 100) * 100;
+		if(year < CURRENT_YEAR) year += 100;
+	}
+}

--- a/src/x86_64/kernel/drivers/timer.c
+++ b/src/x86_64/kernel/drivers/timer.c
@@ -1,32 +1,37 @@
 
-#include <timer.h>
 #include <interrupts.h>
+#include <timer.h>
 
 uint64_t tick = 0;
 
-bool timer_callback()
-{
-    tick++;
-    printf("%i\n", tick);
+bool timer_callback() {
+	tick++;
 
-    return true;
+	return true;
 }
 
-void init_timer(uint32_t freq)
-{
-    /* Install the function we just wrote */
+uint64_t ms_since_bootup() { return tick; }
 
-    interrupt_register_handler(32, timer_callback);
-    printf("%i\n", interrupt_check_handler(32));
+void sleep(uint64_t ms) {
+	uint64_t t = tick + ms;
+	while(tick < t)
+		;
+}
 
-    /* Get the PIT value: hardware clock at 1193180 Hz */
-    uint32_t divisor = 1193180 / freq;
-    printf("Running at %i Hz\n", divisor);
-    uint8_t low = (uint8_t)(divisor & 0xFF);
-    uint8_t high = (uint8_t)((divisor >> 8) % 0xFF);
+void init_timer(uint32_t freq) {
+	/* Install the function we just wrote */
 
-    /* Send the command */
-    outportb(0x43, 0x36); /* Command port */
-    outportb(0x40, low);
-    outportb(0x40, high);
+	interrupt_register_handler(32, timer_callback);
+	printf("%i\n", interrupt_check_handler(32));
+
+	/* Get the PIT value: hardware clock at 1193180 Hz */
+	uint32_t divisor = 1193180 / freq;
+	printf("Running at %i Hz\n", divisor);
+	uint8_t low = (uint8_t)(divisor & 0xFF);
+	uint8_t high = (uint8_t)((divisor >> 8) % 0xFF);
+
+	/* Send the command */
+	outportb(0x43, 0x36); /* Command port */
+	outportb(0x40, low);
+	outportb(0x40, high);
 }

--- a/src/x86_64/kernel/system/main.c
+++ b/src/x86_64/kernel/system/main.c
@@ -1,31 +1,31 @@
 
-#include <multiboot2.h>
+#include <IO.h>
 #include <bootconstants.h>
 #include <kernel.h>
+#include <keyboard.h>
+#include <multiboot2.h>
+#include <serial.h>
 #include <system.h>
 #include <timer.h>
-#include <IO.h>
-#include <keyboard.h>
-#include <serial.h>
 
-bool divbyzero()
-{
+bool divbyzero() {
 	printf("division by zero");
 	return true;
 }
 
-void kmain(void *multiboot_structure)
-{
+void kmain(void *multiboot_structure) {
 	UNUSED(multiboot_structure);
 	system_init();
 	// int i = 0;
 	// printf("%i",1/i);
-	write_serial_str("hello!");
+	write_serial_str("hello!\n");
 	printf("Hello, world!\n");
 
-	for(;;){
-		char str[2] = {read_serial(),'\0'};
-		printf(str);
-	};
+	printf("test\n");
+	sleep(1000);
+	printf("after 1 ms");
 
+	// clang-format off
+	for(;;);
+	// clang-format on
 }

--- a/src/x86_64/kernel/system/main.c
+++ b/src/x86_64/kernel/system/main.c
@@ -4,6 +4,7 @@
 #include <kernel.h>
 #include <keyboard.h>
 #include <multiboot2.h>
+#include <rtc.h>
 #include <serial.h>
 #include <system.h>
 #include <timer.h>
@@ -23,7 +24,15 @@ void kmain(void *multiboot_structure) {
 
 	printf("test\n");
 	sleep(1000);
-	printf("after 1 ms");
+	printf("after 1 ms\n");
+
+	while(true) {
+		datetime_t dt = get_datetime();
+
+		printf("%i-%i-%i %i:%i:%i\n", dt.year, dt.month, dt.day, dt.hour,
+			   dt.minute, dt.second);
+		sleep(1000);
+	}
 
 	// clang-format off
 	for(;;);


### PR DESCRIPTION
Added rtc clock, for now, considering the lack of networking, the year is set via a macro in the file `rtc.c`. 
It works for the next 100 years, but should ideally be updated every year, or some other way. While this can be updated via a register in the CMOS, qemu doesn't actually support this(?). 

Also added a sleep function!

#9 should first be pulled to prevent conflicts.